### PR TITLE
feat: add useDispatch and useSelector hooks with GlobalContext support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,14 @@ export default createContext(
   rootDuck.reducer,
   rootDuck.initialState,
   "ContextName",
-  enhancer
+  enhancer,
+  useAsGlobalContext
 );
 ```
 
-**Note:** The enhancer may be optionally specified to enhance the context with third-party capabilities such as middleware, time travel, persistence, etc. The only context enhancer that ships with Ducks is [applyMiddleware](#applyMiddlewaremiddlewares).
+**Note**: The `enhancer` may be optionally specified to enhance the context with third-party capabilities such as middleware, time travel, persistence, etc. The only context enhancer that ships with Ducks is [applyMiddleware](#applyMiddlewaremiddlewares).
+
+**Note**: The `useAsGlobalContext` i.e. `global` option; allows for setting a default context that is used by the [`useDispatch`](#useDispatchactionCreatorContext) and [`useSelector`](#useSelectorselectorContext) hooks when no `Context` is supplied. This is useful when creating the context that will be used with the root provider.
 
 Use the state and actions in your component.
 
@@ -51,20 +54,31 @@ Use the state and actions in your component.
 // app.jsx
 export default function App(props) {
   const { state, dispatch } = React.useContext(Context);
+  const count = state[counterDuck.name];
   const increment = React.useCallback(
     () => dispatch(counterDuck.actions.increment()),
     [dispatch]
   );
   return (
     <div>
-      Count: <span>{state[counterDuck.name]}</span>
+      Count: <span>{count}</span>
       <button onClick={increment} />
     </div>
   );
 }
 ```
 
-**Note**: this is equivalent to the class component described below.
+**Note**: The use of `React.useContext` can be replaced with a combination of [`useDispatch`](#useDispatchactionCreatorContext) and [`useSelector`](#useSelectorselectorContext) hooks.
+
+```jsx
+// app.jsx
+...
+  const count = useSelector(state => state[counterDuck.name], Context);
+  const increment = useDispatch(counterDuck.actions.increment, Context);
+...
+```
+
+**Note**: This is equivalent to the class component described below.
 
 ```jsx
 // app.jsx
@@ -155,7 +169,6 @@ As a proof of concept converted the sandbox app from the react-redux basic tutor
 
 ## Next
 
-- Implement slice selectors and `useSelector` hook, [reference][react-redux-useselector]
 - Implement observable pattern for context value, [reference][proposal-observable]
 
 ## Suggestions
@@ -166,5 +179,4 @@ As a proof of concept converted the sandbox app from the react-redux basic tutor
 [proposal-observable]: https://github.com/tc39/proposal-observable
 [react-duck-no-redux]: https://codesandbox.io/s/todo-app-without-redux-9yc57
 [react-redux-tutorial]: https://react-redux.js.org/introduction/basic-tutorial
-[react-redux-useselector]: https://react-redux.js.org/api/hooks#useselector
 [redux-applymiddleware]: https://redux.js.org/api/applymiddleware#applymiddlewaremiddleware

--- a/src/components/Context.tsx
+++ b/src/components/Context.tsx
@@ -1,0 +1,12 @@
+import * as React from "react";
+
+const PlaceholderContext = React.createContext(null);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export let GlobalContext: any = PlaceholderContext;
+
+export function setGlobalContext<T>(Context: React.Context<T>): void {
+    if (GlobalContext !== PlaceholderContext) {
+        throw new Error("Global context can only be set once");
+    }
+    GlobalContext = Context;
+}

--- a/src/components/Provider.tsx
+++ b/src/components/Provider.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
-import { useGetter } from "src/hooks/useGetter";
 import { ActionTypes } from "src/utils/actionTypes";
 import { createAction } from "src/createAction";
+import { useGetter } from "src/hooks/useGetter";
 
 export function Provider<S, T extends string, P>({
     children,

--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -1,5 +1,6 @@
 import * as React from "react";
 import { SymbolObservable } from "./utils/symbolObservable";
+import { setGlobalContext } from "./components/Context";
 
 function createUnimplemented(objectName?: string): (m: string) => () => never {
     const prefix = objectName ? `${objectName}.` : "";
@@ -15,6 +16,7 @@ export function createContext<S, T extends string, P>(
     preloadedState: S,
     enhancer?: ContextEnhance<S, T, P>,
     displayName?: string,
+    global = false,
 ): Context<S, T, P> {
     const unimplemented = createUnimplemented(`Context(${displayName ?? ""})`);
     const Context = React.createContext<ContextValue<S, T, P>>({
@@ -27,6 +29,9 @@ export function createContext<S, T extends string, P>(
     });
     if (displayName) {
         Context.displayName = displayName;
+    }
+    if (global) {
+        setGlobalContext(Context);
     }
     return Context;
 }

--- a/src/createRootDuck.ts
+++ b/src/createRootDuck.ts
@@ -1,4 +1,5 @@
 import { combineReducers } from "./utils/combineReducers";
+import { combineSelectors } from "./utils/combineSelectors";
 
 export function createRootDuck<
     D extends Duck<S, N, T, P, R, Q, U>[],
@@ -22,7 +23,10 @@ export function createRootDuck<
         const duckName = duck.name;
         rootDuck.actions[duckName] = duck.actions;
         rootDuck.initialState[duckName] = duck.initialState;
-        rootDuck.selectors[duckName] = duck.selectors;
+        rootDuck.selectors[duckName] = combineSelectors(
+            duckName,
+            duck.selectors,
+        );
         reducerMapping[duckName] = duck.reducer;
     }
     rootDuck.reducer = combineReducers(rootDuck.initialState, reducerMapping);

--- a/src/hooks/useDispatch.ts
+++ b/src/hooks/useDispatch.ts
@@ -1,0 +1,16 @@
+import * as React from "react";
+import { GlobalContext } from "src/components/Context";
+
+export function useDispatch<S, T extends string, P>(
+    actionCreator: ActionCreator<T, P>,
+    Context?: Context<S, T, P>,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+): (...args: any[]) => void {
+    const { dispatch } = React.useContext(Context ?? GlobalContext);
+    return React.useCallback(
+        function dispatchAction(...args) {
+            dispatch(actionCreator(...args));
+        },
+        [actionCreator, dispatch],
+    );
+}

--- a/src/hooks/useSelector.ts
+++ b/src/hooks/useSelector.ts
@@ -1,0 +1,10 @@
+import * as React from "react";
+import { GlobalContext } from "src/components/Context";
+
+export function useSelector<S, R, T extends string, P>(
+    selector: Selector<S, R, T, P> | undefined,
+    Context?: Context<S, T, P>,
+): R | undefined {
+    const { state } = React.useContext(Context ?? GlobalContext);
+    return React.useMemo(() => selector?.(state), [selector, state]);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export { GlobalContext } from "./components/Context";
 export { Provider } from "./components/Provider";
 export { applyMiddleware } from "./utils/applyMiddleware";
 export { createAction } from "./createAction";
@@ -6,3 +7,5 @@ export { createDuck } from "./createDuck";
 export { createReducer } from "./createReducer";
 export { createRootDuck } from "./createRootDuck";
 export { createRootProvider } from "./createRootProvider";
+export { useDispatch } from "./hooks/useDispatch";
+export { useSelector } from "./hooks/useSelector";

--- a/src/utils/combineSelectors.ts
+++ b/src/utils/combineSelectors.ts
@@ -1,0 +1,19 @@
+export function combineSelectors<
+    S,
+    T extends string,
+    P,
+    R,
+    N extends string,
+    Q extends string
+>(
+    duckName: N,
+    selectors?: SelectorMapping<S, R, T, P, Q>,
+): SelectorMapping<S, R, T, P, Q> | undefined {
+    if (!selectors) return;
+    const duckSelectors = {} as SelectorMapping<S, R, T, P, Q>;
+    for (const s of Object.keys(selectors) as Q[]) {
+        duckSelectors[s] = (state: S): R =>
+            selectors[s](((state as unknown) as Record<string, S>)[duckName]);
+    }
+    return duckSelectors;
+}

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { act, cleanup, render } from "@testing-library/react";
-import { Provider } from "src";
+import { Provider, createContext } from "src";
 import { createMocks } from "./mocks";
 
 describe("e2e", (): void => {
@@ -17,6 +17,12 @@ describe("e2e", (): void => {
         init.mockClear();
         jest.clearAllMocks();
         cleanup();
+    });
+
+    it("Does not allow setting the global context multiple times", () => {
+        expect(() => {
+            createContext((s) => s, null, undefined, "NewGlobalContext", true);
+        }).toThrow("Global context can only be set once");
     });
 
     it("Renders without root provider", async () => {

--- a/tests/mocks.tsx
+++ b/tests/mocks.tsx
@@ -6,6 +6,7 @@ import {
     createRootDuck,
     createRootProvider,
 } from "src";
+import { useSelector } from "src/hooks/useSelector";
 import { ActionTypes } from "src/utils/actionTypes";
 
 export function createMocks(): {
@@ -15,12 +16,13 @@ export function createMocks(): {
     increment: jest.MockedFunction<(s: number) => number>;
     init: jest.MockedFunction<() => boolean>;
 } {
-    const increment = jest.fn((state: number): number => state + 1);
+    const increment = jest.fn((state): number => state + 1);
     const decrement = (state: number): number => state - 1;
     const counterDuck = createDuck({
         name: "counter",
         initialState: 0,
         reducers: { decrement, increment },
+        selectors: { get: (state): number => state },
     });
 
     const init = jest.fn((): boolean => true);
@@ -28,24 +30,33 @@ export function createMocks(): {
         name: "init",
         initialState: false,
         reducers: { init },
+        selectors: { get: (state): boolean => state },
         actionMapping: { [ActionTypes.INIT]: "init" },
     });
 
     const rootDuck = createRootDuck(counterDuck, initDuck);
 
-    const Context = createContext(rootDuck.reducer, rootDuck.initialState);
+    const Context = createContext(
+        rootDuck.reducer,
+        rootDuck.initialState,
+        undefined,
+        "GlobalContext",
+        true,
+    );
 
     const RootProvider = createRootProvider(Context);
 
     function Example(): React.ReactElement {
-        const { dispatch, state } = React.useContext(Context);
+        const { dispatch } = React.useContext(Context);
         const increment = React.useCallback(() => {
             dispatch(counterDuck.actions.increment());
         }, [dispatch]);
+        const init = useSelector(rootDuck.selectors.init?.get);
+        const count = useSelector(rootDuck.selectors.counter?.get, Context);
         return (
             <div>
-                Count: <span>{state[counterDuck.name]}</span>
-                <button disabled={!state[initDuck.name]} onClick={increment}>
+                Count: <span>{count}</span>
+                <button disabled={!init} onClick={increment}>
                     increment
                 </button>
             </div>

--- a/tests/mocks.tsx
+++ b/tests/mocks.tsx
@@ -6,6 +6,7 @@ import {
     createRootDuck,
     createRootProvider,
 } from "src";
+import { useDispatch } from "src/hooks/useDispatch";
 import { useSelector } from "src/hooks/useSelector";
 import { ActionTypes } from "src/utils/actionTypes";
 
@@ -47,10 +48,7 @@ export function createMocks(): {
     const RootProvider = createRootProvider(Context);
 
     function Example(): React.ReactElement {
-        const { dispatch } = React.useContext(Context);
-        const increment = React.useCallback(() => {
-            dispatch(counterDuck.actions.increment());
-        }, [dispatch]);
+        const increment = useDispatch(counterDuck.actions.increment);
         const init = useSelector(rootDuck.selectors.init?.get);
         const count = useSelector(rootDuck.selectors.counter?.get, Context);
         return (


### PR DESCRIPTION
# Description

Adds `useDispatch` and `useSelector` hooks with `GlobalContext` support.

## Changes

- exports `GlobalContext` react context
- exports `useDispatch` hook
- exports `useSelector` hook

### Checklist

- [x] This PR has updated documentation
- [x] This PR has sufficient testing

### Comments

- N/A
