### PR TITLE
fix: support for legacy reducer types

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,10 +2,11 @@
     "parser": "@typescript-eslint/parser",
     "extends": [
         "plugin:@typescript-eslint/recommended",
-        "prettier/@typescript-eslint",
+        "plugin:jest/all",
         "plugin:prettier/recommended",
         "plugin:react/recommended",
-        "plugin:react-hooks/recommended"
+        "plugin:react-hooks/recommended",
+        "prettier/@typescript-eslint"
     ],
     "env": {
         "browser": true,
@@ -42,9 +43,8 @@
         "sort-imports": [2,  {
             "ignoreDeclarationSort": true
         }],
-        "react/jsx-first-prop-new-line": [2, "multiline"],
-        "react/jsx-indent": [2, 4],
-        "react/jsx-indent-props": [2, 4],
+        "jest/no-hooks": 0,
+        "jest/prefer-expect-assertions": 0,
         "prettier/prettier": [2, {
             "bracketSpacing": true,
             "jsxBracketSameLine": false,
@@ -52,7 +52,10 @@
             "singleQuote": false,
             "tabWidth": 4,
             "trailingComma": "all"
-        }]
+        }],
+        "react/jsx-first-prop-new-line": [2, "multiline"],
+        "react/jsx-indent": [2, 4],
+        "react/jsx-indent-props": [2, 4]
     },
     "settings": {
         "import/resolver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4320,6 +4320,22 @@
                 }
             }
         },
+        "@typescript-eslint/scope-manager": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.1.0.tgz",
+            "integrity": "sha512-HD1/u8vFNnxwiHqlWKC/Pigdn0Mvxi84Y6GzbZ5f5sbLrFKu0al02573Er+D63Sw67IffVUXR0uR8rpdfdk+vA==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/types": "4.1.0",
+                "@typescript-eslint/visitor-keys": "4.1.0"
+            }
+        },
+        "@typescript-eslint/types": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.1.0.tgz",
+            "integrity": "sha512-rkBqWsO7m01XckP9R2YHVN8mySOKKY2cophGM8K5uDK89ArCgahItQYdbg/3n8xMxzu2elss+an1TphlUpDuJw==",
+            "dev": true
+        },
         "@typescript-eslint/typescript-estree": {
             "version": "2.34.0",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz",
@@ -4368,6 +4384,24 @@
                     "version": "7.3.2",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
                     "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+                    "dev": true
+                }
+            }
+        },
+        "@typescript-eslint/visitor-keys": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.1.0.tgz",
+            "integrity": "sha512-+taO0IZGCtCEsuNTTF2Q/5o8+fHrlml8i9YsZt2AiDCdYEJzYlsmRY991l/6f3jNXFyAWepdQj7n8Na6URiDRQ==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/types": "4.1.0",
+                "eslint-visitor-keys": "^2.0.0"
+            },
+            "dependencies": {
+                "eslint-visitor-keys": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+                    "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
                     "dev": true
                 }
             }
@@ -7672,6 +7706,77 @@
                 }
             }
         },
+        "eslint-plugin-jest": {
+            "version": "24.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.0.1.tgz",
+            "integrity": "sha512-8tYFDqOHGr7vVfdVYspmlV4sRBTylrM4gSLgkGKlO6F+djDOEJ+tEU7I50smUs7AIvFnNZutXUQAMgI9s9N6xQ==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/experimental-utils": "^4.0.1"
+            },
+            "dependencies": {
+                "@typescript-eslint/experimental-utils": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.1.0.tgz",
+                    "integrity": "sha512-paEYLA37iqRIDPeQwAmoYSiZ3PiHsaAc3igFeBTeqRHgPnHjHLJ9OGdmP6nwAkF65p2QzEsEBtpjNUBWByNWzA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/json-schema": "^7.0.3",
+                        "@typescript-eslint/scope-manager": "4.1.0",
+                        "@typescript-eslint/types": "4.1.0",
+                        "@typescript-eslint/typescript-estree": "4.1.0",
+                        "eslint-scope": "^5.0.0",
+                        "eslint-utils": "^2.0.0"
+                    }
+                },
+                "@typescript-eslint/typescript-estree": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.1.0.tgz",
+                    "integrity": "sha512-r6et57qqKAWU173nWyw31x7OfgmKfMEcjJl9vlJEzS+kf9uKNRr4AVTRXfTCwebr7bdiVEkfRY5xGnpPaNPe4Q==",
+                    "dev": true,
+                    "requires": {
+                        "@typescript-eslint/types": "4.1.0",
+                        "@typescript-eslint/visitor-keys": "4.1.0",
+                        "debug": "^4.1.1",
+                        "globby": "^11.0.1",
+                        "is-glob": "^4.0.1",
+                        "lodash": "^4.17.15",
+                        "semver": "^7.3.2",
+                        "tsutils": "^3.17.1"
+                    }
+                },
+                "eslint-utils": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+                    "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
+                    "dev": true,
+                    "requires": {
+                        "eslint-visitor-keys": "^1.1.0"
+                    }
+                },
+                "eslint-visitor-keys": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+                    "dev": true
+                },
+                "is-glob": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
+                    "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+                    "dev": true,
+                    "requires": {
+                        "is-extglob": "^2.1.1"
+                    }
+                },
+                "semver": {
+                    "version": "7.3.2",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+                    "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
+                    "dev": true
+                }
+            }
+        },
         "eslint-plugin-jsx-a11y": {
             "version": "6.3.1",
             "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.3.1.tgz",
@@ -7767,6 +7872,35 @@
             "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.1.1.tgz",
             "integrity": "sha512-vFJNwsf4MLYS0lHYfz9LqxQ+GccYsGGeKPHDxgkIaKbAhNuTLnST+q44pt81MzJZyFU5K4XLF6WiCGv3Yb6tCg==",
             "dev": true
+        },
+        "eslint-scope": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+            "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
+            "dev": true,
+            "requires": {
+                "esrecurse": "^4.3.0",
+                "estraverse": "^4.1.1"
+            },
+            "dependencies": {
+                "esrecurse": {
+                    "version": "4.3.0",
+                    "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+                    "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+                    "dev": true,
+                    "requires": {
+                        "estraverse": "^5.2.0"
+                    },
+                    "dependencies": {
+                        "estraverse": {
+                            "version": "5.2.0",
+                            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+                            "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+                            "dev": true
+                        }
+                    }
+                }
+            }
         },
         "eslint-utils": {
             "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
         "eslint-config-airbnb": "^18.2.0",
         "eslint-config-prettier": "^6.11.0",
         "eslint-plugin-import": "^2.22.0",
+        "eslint-plugin-jest": "^24.0.1",
         "eslint-plugin-jsx-a11y": "^6.3.1",
         "eslint-plugin-prettier": "^3.1.4",
         "eslint-plugin-react": "^7.20.6",

--- a/src/components/Provider.tsx
+++ b/src/components/Provider.tsx
@@ -20,11 +20,14 @@ export function Provider<S, T extends string, P>({
         [reducerDispatch],
     );
 
-    const enhanced = React.useMemo<ContextValue<S, T, P>>(() => {
-        const { enhancer, ...value } = root;
-        Object.assign(value, { dispatch, getState });
-        return enhancer?.(value) ?? value;
-    }, [dispatch, getState, root]);
+    const enhanced = React.useMemo<ContextValue<S, T, P>>(
+        function enhance() {
+            const { enhancer, ...value } = root;
+            Object.assign(value, { dispatch, getState });
+            return enhancer?.(value) ?? value;
+        },
+        [dispatch, getState, root],
+    );
 
     React.useEffect(
         function initialiseContext() {

--- a/src/components/Provider.tsx
+++ b/src/components/Provider.tsx
@@ -37,7 +37,9 @@ export function Provider<S, T extends string, P>({
     );
 
     const value = React.useMemo<ContextValue<S, T, P>>(
-        () => ({ ...enhanced, state }),
+        function getValue() {
+            return { ...enhanced, state };
+        },
         [enhanced, state],
     );
 

--- a/src/createAction.ts
+++ b/src/createAction.ts
@@ -2,7 +2,7 @@ export function createAction<T extends string, P, S>(
     type: T,
     prepare = (payload?: P): Partial<Action<T, P>> => ({ payload }),
 ): ActionCreator<T, P, S> {
-    return (payload): Action<T, P> => {
+    return function createAction(payload): Action<T, P> {
         const partialAction = prepare(payload);
         return { ...partialAction, type };
     };

--- a/src/createContext.ts
+++ b/src/createContext.ts
@@ -4,8 +4,8 @@ import { setGlobalContext } from "./components/Context";
 
 function createUnimplemented(objectName?: string): (m: string) => () => never {
     const prefix = objectName ? `${objectName}.` : "";
-    return function unimplemented(methodName) {
-        return (): never => {
+    return function createUnimplemented(methodName) {
+        return function unimplemented(): never {
             throw new Error(`Unimplemented method: ${prefix}${methodName}`);
         };
     };

--- a/src/createReducer.ts
+++ b/src/createReducer.ts
@@ -1,24 +1,22 @@
 export function createReducer<
     S,
     P,
-    T extends string /* All action types the final reducer supports */,
-    K extends ActionReducerMapping<
+    T extends string /* All action types the final reducer supports */
+>(
+    initialState: S,
+    actionTypeToReducer: ActionReducerMapping<
         S,
         T,
         P
-    > /* Action types to reducer mapping */
->(
-    initialState: S,
-    actionTypeToReducer: K,
+    > /* Action types to reducer mapping */,
     defaultReducer?: Reducer<S, T, P>,
 ): Reducer<S, T, P> {
-    const isReducerActionType = (a: Action<string, P>): boolean =>
-        Boolean(
-            Object.prototype.hasOwnProperty.call(actionTypeToReducer, a.type),
-        );
+    const isReducerActionType = (a?: Action<string, P>): a is Action<T, P> =>
+        a !== undefined &&
+        Object.prototype.hasOwnProperty.call(actionTypeToReducer, a.type);
 
-    return (state = initialState, action?): S => {
-        if (action === undefined || !isReducerActionType(action)) {
+    return function actionReducer(state = initialState, action?): S {
+        if (!isReducerActionType(action)) {
             return defaultReducer?.(state, action) ?? state;
         }
         return actionTypeToReducer[action.type](state, action);

--- a/src/hooks/useDispatch.ts
+++ b/src/hooks/useDispatch.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { GlobalContext } from "../components/Context";
+import { GlobalContext } from "..";
 
 export function useDispatch<S, T extends string, P>(
     actionCreator: ActionCreator<T, P>,

--- a/src/hooks/useGetter.ts
+++ b/src/hooks/useGetter.ts
@@ -2,9 +2,12 @@ import * as React from "react";
 
 export function useGetter<R>(value: R): () => R {
     const ref = React.useRef(value);
-    React.useEffect(() => {
-        ref.current = value;
-    }, [value]);
+    React.useEffect(
+        function updateRef() {
+            ref.current = value;
+        },
+        [value],
+    );
     return React.useCallback(
         function getValue() {
             return ref.current;

--- a/src/hooks/useSelector.ts
+++ b/src/hooks/useSelector.ts
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { GlobalContext } from "../components/Context";
+import { GlobalContext } from "..";
 
 export function useSelector<S, R, T extends string, P>(
     selector: Selector<S, R, T, P> | undefined,

--- a/src/hooks/useSelector.ts
+++ b/src/hooks/useSelector.ts
@@ -6,5 +6,10 @@ export function useSelector<S, R, T extends string, P>(
     Context?: Context<S, T, P>,
 ): R | undefined {
     const { state } = React.useContext(Context ?? GlobalContext);
-    return React.useMemo(() => selector?.(state), [selector, state]);
+    return React.useMemo(
+        function select() {
+            return selector?.(state);
+        },
+        [selector, state],
+    );
 }

--- a/src/utils/applyMiddleware.ts
+++ b/src/utils/applyMiddleware.ts
@@ -7,12 +7,13 @@ export function applyMiddleware<S, T extends string, P>(
     return function enhancer(
         context: ContextValue<S, T, P>,
     ): ContextValue<S, T, P> {
-        const dispatchStub: ContextDispatch<T, P> = () => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        function dispatchStub(...args: unknown[]): never {
             throw new Error(
                 "Dispatching while constructing your middleware is not allowed. " +
                     "Other middleware would not be applied to this dispatch.",
             );
-        };
+        }
 
         const middlewareAPI: MiddlewareAPI<S, T, P> = {
             getState: context.getState,

--- a/src/utils/applyMiddleware.ts
+++ b/src/utils/applyMiddleware.ts
@@ -17,7 +17,7 @@ export function applyMiddleware<S, T extends string, P>(
 
         const middlewareAPI: MiddlewareAPI<S, T, P> = {
             getState: context.getState,
-            dispatch: (action, ...args) => dispatchStub(action, ...args),
+            dispatch: dispatchStub,
         };
         const chain = middlewares.map((middleware) =>
             middleware(middlewareAPI),

--- a/src/utils/combineReducers.ts
+++ b/src/utils/combineReducers.ts
@@ -9,7 +9,7 @@ export function combineReducers<S, N extends string, T extends string, P>(
         state: Record<N, S> = initialState,
         action,
     ): Record<string, S> {
-        return reducers.reduce((acc, [name, reducer]) => {
+        return reducers.reduce(function reduce(acc, [name, reducer]) {
             acc[name] = reducer(state[name], action);
             return acc;
         }, {} as Record<N, S>);

--- a/src/utils/getEntries.ts
+++ b/src/utils/getEntries.ts
@@ -1,3 +1,3 @@
-export function getEntries<A extends string, B>(o?: Record<A, B>): [A, B][] {
-    return (o ? Object.entries(o) : []) as [A, B][];
+export function getEntries<A extends string, B>(o: Record<A, B>): [A, B][] {
+    return Object.entries(o) as [A, B][];
 }

--- a/tests/__mocks__/index.tsx
+++ b/tests/__mocks__/index.tsx
@@ -17,22 +17,38 @@ export function createMocks(): {
     increment: jest.MockedFunction<(s: number) => number>;
     init: jest.MockedFunction<() => boolean>;
 } {
-    const increment = jest.fn((state): number => state + 1);
+    const DECREMENT = "decrement";
+    const INCREMENT = "increment";
     const decrement = (state: number): number => state - 1;
+    const increment = jest.fn((state): number => state + 1);
+    const counterReducer: (s: number, a?: Action<string>) => number = (
+        state,
+        action,
+    ) => {
+        switch (action?.type) {
+            case DECREMENT:
+                return decrement(state);
+            case INCREMENT:
+                return increment(state);
+            default:
+                return state;
+        }
+    };
     const counterDuck = createDuck({
         name: "counter",
         initialState: 0,
-        reducers: { decrement, increment },
+        reducers: { [DECREMENT]: counterReducer, [INCREMENT]: counterReducer },
         selectors: { get: (state): number => state },
     });
 
+    const INIT = "init";
     const init = jest.fn((): boolean => true);
     const initDuck = createDuck({
         name: "init",
         initialState: false,
-        reducers: { init },
+        reducers: { [INIT]: init },
         selectors: { get: (state): boolean => state },
-        actionMapping: { [ActionTypes.INIT]: "init" },
+        actionMapping: { [ActionTypes.INIT]: INIT },
     });
 
     const rootDuck = createRootDuck(counterDuck, initDuck);

--- a/tests/__mocks__/index.tsx
+++ b/tests/__mocks__/index.tsx
@@ -5,9 +5,9 @@ import {
     createDuck,
     createRootDuck,
     createRootProvider,
+    useDispatch,
+    useSelector,
 } from "src";
-import { useDispatch } from "src/hooks/useDispatch";
-import { useSelector } from "src/hooks/useSelector";
 import { ActionTypes } from "src/utils/actionTypes";
 
 export function createMocks(): {
@@ -18,6 +18,12 @@ export function createMocks(): {
     increment: jest.MockedFunction<(s: number) => number>;
     init: jest.MockedFunction<() => boolean>;
 } {
+    const dummyMiddleware: Middleware<
+        Record<string, unknown>,
+        string,
+        unknown
+    > = () => (next) => (action): typeof action => next(action);
+
     const DECREMENT = "decrement";
     const INCREMENT = "increment";
     const decrement = (state: number): number => state - 1;
@@ -57,7 +63,7 @@ export function createMocks(): {
     const Context = createContext(
         rootDuck.reducer,
         rootDuck.initialState,
-        applyMiddleware(),
+        applyMiddleware(dummyMiddleware),
         "GlobalContext",
         true,
     );
@@ -77,12 +83,6 @@ export function createMocks(): {
             </div>
         );
     }
-
-    const dummyMiddleware: Middleware<
-        Record<string, unknown>,
-        string,
-        unknown
-    > = () => (next) => (action): typeof action => next(action);
 
     const logger: Middleware<Record<string, unknown>, string, unknown> = ({
         getState,

--- a/tests/__mocks__/index.tsx
+++ b/tests/__mocks__/index.tsx
@@ -78,6 +78,12 @@ export function createMocks(): {
         );
     }
 
+    const dummyMiddleware: Middleware<
+        Record<string, unknown>,
+        string,
+        unknown
+    > = () => (next) => (action): typeof action => next(action);
+
     const logger: Middleware<Record<string, unknown>, string, unknown> = ({
         getState,
     }) => (next) => (action): typeof action => {
@@ -96,7 +102,7 @@ export function createMocks(): {
     const EnhancedContext = createContext(
         rootDuck.reducer,
         rootDuck.initialState,
-        applyMiddleware(logger),
+        applyMiddleware(dummyMiddleware, logger),
         "EnhancedContext",
     );
 
@@ -112,7 +118,7 @@ export function createMocks(): {
     const ErrorContext = createContext(
         emptyRootDuck.reducer,
         emptyRootDuck.initialState,
-        applyMiddleware(logger, badMiddleware),
+        applyMiddleware(dummyMiddleware, badMiddleware),
         "ErrorContext",
     );
 

--- a/tests/__mocks__/index.tsx
+++ b/tests/__mocks__/index.tsx
@@ -57,7 +57,7 @@ export function createMocks(): {
     const Context = createContext(
         rootDuck.reducer,
         rootDuck.initialState,
-        undefined,
+        applyMiddleware(),
         "GlobalContext",
         true,
     );
@@ -108,10 +108,11 @@ export function createMocks(): {
         dispatch({ type: "SOME_ACTION" });
         return () => (action): typeof action => action;
     };
+    const emptyRootDuck = createRootDuck();
     const ErrorContext = createContext(
-        rootDuck.reducer,
-        rootDuck.initialState,
-        applyMiddleware(badMiddleware),
+        emptyRootDuck.reducer,
+        emptyRootDuck.initialState,
+        applyMiddleware(logger, badMiddleware),
         "ErrorContext",
     );
 

--- a/tests/__mocks__/index.tsx
+++ b/tests/__mocks__/index.tsx
@@ -12,6 +12,7 @@ import { ActionTypes } from "src/utils/actionTypes";
 
 export function createMocks(): {
     EnhancedContext: Context<Record<string, unknown>>;
+    ErrorContext: Context<Record<string, unknown>>;
     Example: React.FunctionComponent;
     RootProvider: React.FunctionComponent;
     increment: jest.MockedFunction<(s: number) => number>;
@@ -99,8 +100,24 @@ export function createMocks(): {
         "EnhancedContext",
     );
 
+    const badMiddleware: Middleware<
+        Record<string, unknown>,
+        string,
+        unknown
+    > = ({ dispatch }) => {
+        dispatch({ type: "SOME_ACTION" });
+        return () => (action): typeof action => action;
+    };
+    const ErrorContext = createContext(
+        rootDuck.reducer,
+        rootDuck.initialState,
+        applyMiddleware(badMiddleware),
+        "ErrorContext",
+    );
+
     return {
         EnhancedContext,
+        ErrorContext,
         Example,
         RootProvider,
         increment,

--- a/tests/__snapshots__/index.test.tsx.snap
+++ b/tests/__snapshots__/index.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`e2e Renders with root provider and updates on action dispatch 1`] = `
+exports[`e2e renders with root provider and updates on action dispatch 1`] = `
 <body>
   <div>
     <div>
@@ -16,7 +16,7 @@ exports[`e2e Renders with root provider and updates on action dispatch 1`] = `
 </body>
 `;
 
-exports[`e2e Renders without root provider 1`] = `
+exports[`e2e renders without root provider 1`] = `
 <body>
   <div>
     <div>

--- a/tests/createAction.test.ts
+++ b/tests/createAction.test.ts
@@ -9,7 +9,7 @@ describe("createAction", () => {
             payload,
             error: true,
         }));
-        expect(actionCreator(payload)).toEqual({
+        expect(actionCreator(payload)).toStrictEqual({
             error: true,
             payload,
             type: type,

--- a/tests/createContext.test.ts
+++ b/tests/createContext.test.ts
@@ -14,6 +14,14 @@ describe("createContext", () => {
         expect(Context.displayName).toEqual("TextContext");
     });
 
+    it("has default dispatch and getState", () => {
+        const initialState = {};
+        const Context = createContext((s) => s, initialState);
+        const { result } = renderHook(() => React.useContext(Context));
+        expect(result.current.dispatch).not.toThrow();
+        expect(result.current.getState()).toEqual(initialState);
+    });
+
     it("has unimplemented observable symbol", () => {
         const Context = createContext((s) => s, {});
         const { result } = renderHook(() => React.useContext(Context));

--- a/tests/createContext.test.ts
+++ b/tests/createContext.test.ts
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { renderHook } from "@testing-library/react-hooks";
-import { createContext } from "src";
+import { applyMiddleware, createContext } from "src";
 import { SymbolObservable } from "src/utils/symbolObservable";
 
 describe("createContext", () => {
@@ -19,7 +19,20 @@ describe("createContext", () => {
         const Context = createContext((s) => s, initialState);
         const { result } = renderHook(() => React.useContext(Context));
         expect(result.current.dispatch).not.toThrow();
+        expect(result.current.enhancer).toBeUndefined();
         expect(result.current.getState()).toStrictEqual(initialState);
+    });
+
+    it("provides and can use empty enhancer from applyMiddleware", () => {
+        const initialState = {};
+        const Context = createContext(
+            (s) => s,
+            initialState,
+            applyMiddleware(),
+        );
+        const { result } = renderHook(() => React.useContext(Context));
+        const { enhancer, ...value } = result.current;
+        expect(enhancer?.(value)).toMatchObject(value);
     });
 
     it("has unimplemented observable symbol", () => {

--- a/tests/createContext.test.ts
+++ b/tests/createContext.test.ts
@@ -6,12 +6,12 @@ import { SymbolObservable } from "src/utils/symbolObservable";
 describe("createContext", () => {
     it("creates context without displayname", () => {
         const Context = createContext((s) => s, {});
-        expect(Context.displayName).toBeUndefined;
+        expect(Context.displayName).toBeUndefined();
     });
 
     it("creates context with displayname", () => {
         const Context = createContext((s) => s, {}, undefined, "TextContext");
-        expect(Context.displayName).toEqual("TextContext");
+        expect(Context.displayName).toBe("TextContext");
     });
 
     it("has default dispatch and getState", () => {
@@ -19,7 +19,7 @@ describe("createContext", () => {
         const Context = createContext((s) => s, initialState);
         const { result } = renderHook(() => React.useContext(Context));
         expect(result.current.dispatch).not.toThrow();
-        expect(result.current.getState()).toEqual(initialState);
+        expect(result.current.getState()).toStrictEqual(initialState);
     });
 
     it("has unimplemented observable symbol", () => {

--- a/tests/createReducer.test.ts
+++ b/tests/createReducer.test.ts
@@ -11,10 +11,10 @@ describe("createReducer", () => {
             [actionType]: (state) => ({ ...state, yes: true }),
         } as Record<string, Reducer<typeof initialState, string>>);
         const state1 = reducer(initialState, unknownAction);
-        expect(state1).toEqual(initialState);
+        expect(state1).toStrictEqual(initialState);
 
         const state2 = reducer(state1, createAction(actionType)());
-        expect(state2).not.toEqual(state1);
+        expect(state2).not.toStrictEqual(state1);
         expect(state2.yes).toBe(true);
     });
 
@@ -29,7 +29,7 @@ describe("createReducer", () => {
             (state) => ({ ...state, yes: "nani!!!" }),
         );
         const state1 = reducer(initialState, unknownAction);
-        expect(state1.yes).toEqual("nani!!!");
+        expect(state1.yes).toBe("nani!!!");
 
         const state2 = reducer(state1, createAction(actionType)());
         expect(state2.yes).toBe("something");

--- a/tests/createReducer.test.ts
+++ b/tests/createReducer.test.ts
@@ -9,7 +9,7 @@ describe("createReducer", () => {
         const initialState = { yes: false };
         const reducer = createReducer(initialState, {
             [actionType]: (state) => ({ ...state, yes: true }),
-        });
+        } as Record<string, Reducer<typeof initialState, string>>);
         const state1 = reducer(initialState, unknownAction);
         expect(state1).toEqual(initialState);
 
@@ -25,7 +25,7 @@ describe("createReducer", () => {
             initialState,
             {
                 [actionType]: (state) => ({ ...state, yes: "something" }),
-            },
+            } as Record<string, Reducer<typeof initialState, string>>,
             (state) => ({ ...state, yes: "nani!!!" }),
         );
         const state1 = reducer(initialState, unknownAction);

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { act, cleanup, render } from "@testing-library/react";
 import { Provider, createContext } from "src";
+// eslint-disable-next-line jest/no-mocks-import
 import { createMocks } from "./__mocks__";
 
 describe("e2e", (): void => {
@@ -20,35 +21,36 @@ describe("e2e", (): void => {
         cleanup();
     });
 
-    it("Does not allow setting the global context multiple times", () => {
+    it("does not allow setting the global context multiple times", () => {
         expect(() => {
             createContext((s) => s, null, undefined, "NewGlobalContext", true);
         }).toThrow("Global context can only be set once");
     });
 
-    it("Renders without root provider", async () => {
+    it("renders without root provider", async () => {
         const result = render(<Example />);
         expect(result.baseElement).toMatchSnapshot();
-        await act(() =>
-            result.findByText("increment").then((element) => element.click()),
-        );
+        const element = await result.findByText("increment");
+        act(() => element.click());
         expect(increment).not.toHaveBeenCalled();
     });
 
-    it("Renders with root provider and updates on action dispatch", async () => {
+    it("renders with root provider and updates on action dispatch", async () => {
         const result = render(
             <RootProvider>
                 <Example />
             </RootProvider>,
         );
-        await act(() => result.findByText("increment").then((e) => e.click()));
-        expect(increment).toHaveBeenCalled();
-        await act(() => result.findByText("increment").then((e) => e.click()));
+        const element = await result.findByText("increment");
+        act(() => element.click());
+        expect(increment).toHaveBeenCalledWith(0);
+        act(() => element.click());
+        expect(increment).toHaveBeenCalledWith(1);
         expect(result.baseElement).toMatchSnapshot();
         expect(init).toHaveBeenCalledTimes(1);
     });
 
-    it("Renders with enhanced context", async () => {
+    it("renders with enhanced context", async () => {
         const spyConsoleLog = jest
             .spyOn(console, "log")
             .mockImplementation(() => undefined);
@@ -59,21 +61,21 @@ describe("e2e", (): void => {
         );
         await Promise.resolve();
         expect(spyConsoleLog).toHaveBeenCalledTimes(2);
-        expect(spyConsoleLog.mock.calls[0]).toEqual([
+        expect(spyConsoleLog.mock.calls[0]).toMatchObject([
             "action to dispatch",
             {
                 payload: undefined,
                 type: expect.stringContaining("@@context/INIT"),
             },
         ]);
-        expect(spyConsoleLog.mock.calls[1]).toEqual([
+        expect(spyConsoleLog.mock.calls[1]).toMatchObject([
             "state after dispatch",
             { counter: 0, init: true },
         ]);
         spyConsoleLog.mockRestore();
     });
 
-    it("Fails to render if middleware dispatches while constructing", () => {
+    it("fails to render if middleware dispatches while constructing", () => {
         const spyConsoleError = jest
             .spyOn(console, "error")
             .mockImplementation(() => undefined);

--- a/typings/duck.d.ts
+++ b/typings/duck.d.ts
@@ -26,8 +26,9 @@ type Reducer<
 type ActionReducerMapping<
     S = unknown,
     T extends string = string,
-    P = unknown
-> = Record<T, Reducer<S, T, P>>;
+    P = unknown,
+    C extends string = T
+> = Record<C, Reducer<S, T, P>>;
 
 type Selector<
     S = unknown,


### PR DESCRIPTION
# Description

Fix support for normal switch case reducer functions not created using `createReducer`

## Changes

Also
- Add jest test linting
- Adds more tests

### Checklist

- [x] This PR has updated documentation
- [x] This PR has sufficient testing

### Comments

- Addition comments for reviewers
